### PR TITLE
Update fma.sh

### DIFF
--- a/scripts/fma.sh
+++ b/scripts/fma.sh
@@ -1,5 +1,7 @@
 cd ../dataset/fma/
 wget https://os.unil.cloud.switch.ch/fma/fma_metadata.zip
 wget https://os.unil.cloud.switch.ch/fma/fma_small.zip
-unzip fma_metadata.zip # 7z x fma_metadata.zip -ofma_metadata
-unzip fma_small.zip # 7z x fma_small.zip -ofma_small
+#unzip fma_metadata.zip # 7z x fma_metadata.zip -ofma_metadata
+7za x fma_metadata.zip
+#unzip fma_small.zip # 7z x fma_small.zip -ofma_small
+7za x fma_small.zip


### PR DESCRIPTION
I'm not sure why I can't unzip fma via typical `unzip` package. But `7z` is work.  Use `7za x {filename} `will keep folder structure like `"unzip"`. If you never meet this problem, skip this pull.
Hikari